### PR TITLE
Transform some implicit any types into explicity

### DIFF
--- a/packages/reim/src/reim.d.ts
+++ b/packages/reim/src/reim.d.ts
@@ -3,8 +3,8 @@ export type Mutation = {(state: State): void | any} | object
 export type Getter = {(state: State):  any}
 
 interface Subscriber {
-  handler(object): void
-  getter(object): any
+  handler(object: any): void
+  getter(object: any): any
 }
 
 interface SubscribeOption {


### PR DESCRIPTION
This allow projects that uses the `noImplicitAny` compiler option.

From the documentation:

> noImplicitAny (boolean, default = false): Raise error on expressions and declarations with an implied any type.